### PR TITLE
fix: Update broken link to Risc Zero website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <a href="https://risczero.com"><img src="website/static/img/logo.png" height="100"></a>
+  <a href="https://www.risczero.com/"><img src="website/static/img/logo.png" height="100"></a>
 </p>
 
-<h1 align="center"><a href="https://risczero.com">RISC Zero</a></h1>
+<h1 align="center"><a href="https://www.risczero.com/">RISC Zero</a></h1>
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][licence-badge]][licence-url]


### PR DESCRIPTION
This commit updates a broken link on Risc Zero's website. The original link (https://risczero.com) was causing a connection error. It has been replaced with the correct URL (https://www.risczero.com).