### PR TITLE
fix: Update broken link to Risc Zero website

### DIFF
--- a/website/api/introduction.md
+++ b/website/api/introduction.md
@@ -23,4 +23,4 @@ program!
 Check out our [Getting Started][docs-getting-started] page.
 
 [docs-getting-started]: ./getting-started.md
-[external-risc-zero]: https://risczero.com
+[external-risc-zero]: https://www.risczero.com


### PR DESCRIPTION
This commit updates a broken link on Risc Zero's website. The original link (https://risczero.com) was causing a connection error. It has been replaced with the correct URL (https://www.risczero.com).